### PR TITLE
Don't send server_max_window_bits unless requested

### DIFF
--- a/lib/permessage_deflate/server_session.rb
+++ b/lib/permessage_deflate/server_session.rb
@@ -52,6 +52,9 @@ class PermessageDeflate
       @peer_context_takeover = !params['client_no_context_takeover']
       @peer_window_bits = params['client_max_window_bits'] || DEFAULT_MAX_WINDOW_BITS
 
+      # Only include server_max_window_bits if requested, because FF will terminate the
+      # connection otherwise: https://bugzilla.mozilla.org/show_bug.cgi?id=1137008
+      params.delete('server_max_window_bits') unless @params['server_max_window_bits']
       params
     end
 

--- a/spec/permessage_deflate/server_session_spec.rb
+++ b/spec/permessage_deflate/server_session_spec.rb
@@ -163,8 +163,8 @@ describe PermessageDeflate::ServerSession do
     before { options[:max_window_bits] = 12 }
 
     describe "with an empty offer" do
-      it "includes server_max_window_bits in the response" do
-        expect(response).to eq("server_max_window_bits" => 12)
+      it "does not include server_max_window_bits in the response" do
+        expect(response).to eq({})
       end
 
       it "uses context takeover and 12 window bits for deflating outgoing messages" do


### PR DESCRIPTION
We recently deployed a chat service using Faye and noticed that we had many more polling connections than anticipated. It turns out Firefox was falling back to polling due to the extension sending `server_max_window_bits` in the response when the client did not include it in the handshake request.

It looks like they have [very recently addressed this](https://bugzilla.mozilla.org/show_bug.cgi?id=1137008), but most users will run into this problem until the fix is widely deployed.

The [spec](http://tools.ietf.org/html/draft-ietf-hybi-permessage-compression-19#section-8.1.2) says the server is not required to send this field if it is not requested, so this patch sends it ONLY if it was included in the client's handshake.

Our production server has now been patched, but previously the following code

``` javascript
new WebSocket('wss://kwak-faye.kongregate.com/faye')
```

Would yield: 
`Firefox can't establish a connection to the server at wss://kwak-faye.kongregate.com/faye.`

If you feel this approach is too heavy handed it could be made optional, but this seems like a good default since the memory savings on the client is minimal unless a ton of sockets are being opened, and this will likely catch anyone using the `server_max_window_bits` option off-guard.
